### PR TITLE
Add Vim Terminal API argument options (-t, -T {prefix})

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ GIMP	gimp
 
 ## Vim Terminal API
 
-`gof -t` or `gof -T [prefix]` opens selected files in Vim using [Terminal
-API](https://vim-jp.org/vimdoc-en/terminal.html#terminal-api).
-This option is ignored when `-l`, `-e`, `-c`, `-r`, or 1 or more non-option
-argument were supplied.
+* `gof -t` or `gof -T [prefix]` opens selected files in Vim using [Terminal
+  API](https://vim-jp.org/vimdoc-en/terminal.html#terminal-api).  This option is
+  ignored when `-l`, `-e`, `-c`, `-r`, or 1 or more non-option argument were
+  supplied
 
-If you want to add `-t` option automatically whether you are inside Vim terminal
-or not, you can define alias like this.
+* If you want to add `-t` option automatically whether you are inside Vim
+  terminal or not, you can define alias like this
 
 ```sh
 gof() {
@@ -107,8 +107,19 @@ gof() {
 }
 ```
 
-If you use `term_setapi()` in your Vim, use `gof -T [prefix]` to specify the
-prefix (but maybe you never use this function :sweat_smile:).
+* If you use `term_setapi()` in your Vim, use `gof -T [prefix]` to specify the
+  prefix (but maybe you never use this function :sweat_smile:)
+
+* You can define utility Vim command `:Gof`. Quickly calls `gof -t` command and
+  opens selected files in Vim buffer
+
+```vim
+if executable('gof')
+  command! -nargs=* Gof term ++close gof -t
+endif
+```
+
+![](https://i.imgur.com/dJ8ypKT.gif)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ $ find /tmp | gof
 
 ## Options
 
-|Option     |Description                             |
-|-----------|----------------------------------------|
-|-c         |Cat the selected file                   |
-|-e         |Edit the selected file                  |
-|-          |Remove the selected file                |
-|-l         |Launcher mode                           |
-|-x         |Exit code for cancel (default: 1)       |
-|-d [path]  |Specify root directory                  |
-|-t         |Open via Vim's Terminal API             |
-|-T [prefix]|Terminal API's prefix (default: "Tapi_")|
+|Option        |Description                      |
+|--------------|---------------------------------|
+|-c            |Cat the selected file            |
+|-e            |Edit the selected file           |
+|-             |Remove the selected file         |
+|-l            |Launcher mode                    |
+|-x            |Exit code for cancel (default: 1)|
+|-d [path]     |Specify root directory           |
+|-t            |Open via Vim's Terminal API      |
+|-tf [funcname]|Terminal API's function name     |
 
 ## Launcher Mode
 
@@ -89,7 +89,7 @@ GIMP	gimp
 
 ## Vim Terminal API
 
-* `gof -t` or `gof -T [prefix]` opens selected files in Vim using [Terminal
+* `gof -t` or `gof -tf [prefix]` opens selected files in Vim using [Terminal
   API](https://vim-jp.org/vimdoc-en/terminal.html#terminal-api).  This option is
   ignored when `-l`, `-e`, `-c`, `-r`, or 1 or more non-option argument were
   supplied
@@ -107,8 +107,7 @@ gof() {
 }
 ```
 
-* If you use `term_setapi()` in your Vim, use `gof -T [prefix]` to specify the
-  prefix (but maybe you never use this function :sweat_smile:)
+* If you are familiar with Vim script, you may want to send `["call", "[funcname]", "[filename]"]` instead of `["drop", "[filename]"]`. You can use `gof -tf [funcname]` to send `call` command
 
 * You can define utility Vim command `:Gof`. Quickly calls `gof -t` command and
   opens selected files in Vim buffer

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Go Fuzzy
 
 ![](http://i.imgur.com/TGZJyGV.gif)
 
+[Open files in Vim directly (inside Vim terminal)](#vim-terminal-api)
+
+![](https://i.imgur.com/g81MCyr.gif)
+
 ## Installation
 
     $ go get github.com/mattn/gof
@@ -56,14 +60,16 @@ $ find /tmp | gof
 
 ## Options
 
-|Option   |Description                      |
-|---------|---------------------------------|
-|-c       |Cat the selected file            |
-|-e       |Edit the selected file           |
-|-        |Remove the selected file         |
-|-l       |Launcher mode                    |
-|-x       |Exit code for cancel (default: 1)|
-|-d [path]|Specify root directory           |
+|Option     |Description                             |
+|-----------|----------------------------------------|
+|-c         |Cat the selected file                   |
+|-e         |Edit the selected file                  |
+|-          |Remove the selected file                |
+|-l         |Launcher mode                           |
+|-x         |Exit code for cancel (default: 1)       |
+|-d [path]  |Specify root directory                  |
+|-t         |Open via Vim's Terminal API             |
+|-T [prefix]|Terminal API's prefix (default: "Tapi_")|
 
 ## Launcher Mode
 
@@ -80,6 +86,29 @@ Vim	gvim
 Emacs	emacs
 GIMP	gimp
 ```
+
+## Vim Terminal API
+
+`gof -t` or `gof -T [prefix]` opens selected files in Vim using [Terminal
+API](https://vim-jp.org/vimdoc-en/terminal.html#terminal-api).
+This option is ignored when `-l`, `-e`, `-c`, `-r`, or 1 or more non-option
+argument were supplied.
+
+If you want to add `-t` option automatically whether you are inside Vim terminal
+or not, you can define alias like this.
+
+```sh
+gof() {
+  if [ "$VIM_TERMINAL" ]; then
+    gof -t "$@"
+  else
+    gof "$@"
+  fi
+}
+```
+
+If you use `term_setapi()` in your Vim, use `gof -T [prefix]` to specify the
+prefix (but maybe you never use this function :sweat_smile:).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Go Fuzzy
 
 [Open files in Vim directly (inside Vim terminal)](#vim-terminal-api)
 
-![](https://i.imgur.com/g81MCyr.gif)
+![](https://i.imgur.com/pRhl9o3.gif)
 
 ## Installation
 
@@ -119,7 +119,7 @@ if executable('gof')
 endif
 ```
 
-![](https://i.imgur.com/dJ8ypKT.gif)
+![](https://i.imgur.com/jvfuOxh.gif)
 
 ## License
 

--- a/gof.go
+++ b/gof.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -28,16 +29,16 @@ import (
 var duration = 20 * time.Millisecond
 
 var (
-	edit              = flag.Bool("e", false, "Edit selected file")
-	cat               = flag.Bool("c", false, "Cat the file")
-	remove            = flag.Bool("r", false, "Remove the file")
-	launcher          = flag.Bool("l", false, "Launcher mode")
-	fuzzy             = flag.Bool("f", false, "Fuzzy match")
-	root              = flag.String("d", "", "Root directory")
-	exit              = flag.Int("x", 1, "Exit code for cancel")
-	action            = flag.String("a", "", "Action keys")
-	terminalApi       = flag.Bool("t", false, "Open via Vim's Terminal API")
-	terminalApiPrefix = flag.String("T", "Tapi_", "Terminal API's prefix")
+	edit                = flag.Bool("e", false, "Edit selected file")
+	cat                 = flag.Bool("c", false, "Cat the file")
+	remove              = flag.Bool("r", false, "Remove the file")
+	launcher            = flag.Bool("l", false, "Launcher mode")
+	fuzzy               = flag.Bool("f", false, "Fuzzy match")
+	root                = flag.String("d", "", "Root directory")
+	exit                = flag.Int("x", 1, "Exit code for cancel")
+	action              = flag.String("a", "", "Action keys")
+	terminalApi         = flag.Bool("t", false, "Open via Vim's Terminal API")
+	terminalApiFuncname = flag.String("tf", "", "Terminal API's function name")
 )
 
 func print_tb(x, y int, fg, bg termbox.Attribute, msg string) {
@@ -322,10 +323,10 @@ func main() {
 		*root = flag.Arg(0)
 	}
 
-	*terminalApi = *terminalApiPrefix != "" && (*terminalApi || *terminalApiPrefix != "Tapi_")
+	*terminalApi = *terminalApi || *terminalApiFuncname != ""
 	if *terminalApi {
 		if os.Getenv("VIM_TERMINAL") == "" {
-			fmt.Fprintln(os.Stderr, "-t,-T option is only available inside Vim's terminal window")
+			fmt.Fprintln(os.Stderr, "-t,-tf option is only available inside Vim's terminal window")
 			os.Exit(1)
 		}
 	}
@@ -721,7 +722,18 @@ loop:
 	} else {
 		if *terminalApi {
 			for _, f := range selected {
-				fmt.Printf("\x1b]51;[\"drop\",\"%s\"]\x07", f)
+				command := make([]string, 0, 3)
+				if *terminalApiFuncname != "" {
+					command = append(command, "call", *terminalApiFuncname, f)
+				} else {
+					command = append(command, "drop", f)
+				}
+				b, err := json.Marshal(command)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				fmt.Printf("\x1b]51;%s\x07", string(b))
 			}
 		} else {
 			if *action != "" {


### PR DESCRIPTION
This PR adds below argument options.

* `-t`
* `-T {prefix}`

This allows Vim to open selected file directly from Vim's terminal window.

![](https://i.imgur.com/pRhl9o3.gif)

I wrote about usage to README.