### PR TITLE
Some fixes / destructive changes for -t option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,15 @@ gof() {
 }
 ```
 
-* If you are familiar with Vim script, you may want to send `["call", "[funcname]", "[filename]"]` instead of `["drop", "[filename]"]`. You can use `gof -tf [funcname]` to send `call` command
+* If you are familiar with Vim script, you may want to send `["call", "[funcname]", "[file information]"]` instead of `["drop", "[filename]"]`. You can use `gof -tf [funcname]` to send `call` command
+
+```
+[file information] = {
+  "filename": [relative filename path (string)],
+  "fullpath": [absolute filename path (string)],
+  "root_dir": [root directory (string)]
+}
+```
 
 * You can define utility Vim command `:Gof`. Quickly calls `gof -t` command and
   opens selected files in Vim buffer

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ endif
 
 ![](https://i.imgur.com/jvfuOxh.gif)
 
+* Please try [vargs](https://github.com/tyru/vargs) if you want to communicate easily with Vim terminal API from shell
+
 ## License
 
 MIT

--- a/gof.go
+++ b/gof.go
@@ -722,9 +722,9 @@ loop:
 	} else {
 		if *terminalApi {
 			for _, f := range selected {
-				command := make([]string, 0, 3)
+				command := make([]interface{}, 0, 3)
 				if *terminalApiFuncname != "" {
-					command = append(command, "call", *terminalApiFuncname, f)
+					command = append(command, "call", *terminalApiFuncname, newVimTapiCall(cwd, f))
 				} else {
 					command = append(command, "drop", f)
 				}
@@ -744,4 +744,18 @@ loop:
 			}
 		}
 	}
+}
+
+type vimTapiCall struct {
+	RootDir  string `json:"root_dir"`
+	Filename string `json:"filename"`
+	Fullpath string `json:"fullpath"`
+}
+
+func newVimTapiCall(rootDir, filename string) *vimTapiCall {
+	fullpath := filename
+	if !filepath.IsAbs(filename) {
+		fullpath = filepath.Join(rootDir, filename)
+	}
+	return &vimTapiCall{RootDir: rootDir, Filename: filename, Fullpath: fullpath}
 }

--- a/gof.go
+++ b/gof.go
@@ -726,6 +726,9 @@ loop:
 				if *terminalApiFuncname != "" {
 					command = append(command, "call", *terminalApiFuncname, newVimTapiCall(cwd, f))
 				} else {
+					if !filepath.IsAbs(f) {
+						f = filepath.Join(cwd, f)
+					}
 					command = append(command, "drop", f)
 				}
 				b, err := json.Marshal(command)


### PR DESCRIPTION
* 32921f7b6f3c2881a3d1f8f6ee57abd8f43deda6: Convert relative path to absolute path
  * I could not open file when specifying `-d [dir]` option, because the relative path passed to `drop` command
* 30435f93fad39ebeb5bf2f819380a55a62740b96: Change structure passed to call command
  * I think gof should pass more information to `call`. For example, the root directory (`-d [dir]`). I missed that in previous pull request #14 