### PR TITLE
Add a new mapping <C-r> for toggling fuzzy option

### DIFF
--- a/main.go
+++ b/main.go
@@ -603,6 +603,9 @@ loop:
 					input = append(input[0:cursor_x], input[cursor_x+1:len(input)]...)
 					update = true
 				}
+			case termbox.KeyCtrlR:
+				*fuzzy = !*fuzzy
+				update = true
 			default:
 				if ev.Key == termbox.KeySpace {
 					ev.Ch = ' '


### PR DESCRIPTION
I want a mapping for toggling the fuzzy option. There may be some discussion on the mapping `<C-r>` is ok. I propose this mapping because `<C-r>` in CtrlP toggles the regex option, too.
![gof2](https://user-images.githubusercontent.com/375258/73724791-7817f780-476f-11ea-8d1c-171966125e2d.gif)
