### PR TITLE
Give up case-insensitive matching when strings.ToLower changes the input string

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -165,7 +166,12 @@ func filter() {
 		tmp = make([]matched, 0, len(fs))
 		inpl := strings.ToLower(string(inp))
 		for _, f := range fs {
-			pos := strings.Index(strings.ToLower(f), inpl)
+			var pos int
+			if lf := strings.ToLower(f); len(f) == len(lf) {
+				pos = strings.Index(lf, inpl)
+			} else {
+				pos = bytes.Index([]byte(f), []byte(string(inp)))
+			}
 			if pos == -1 {
 				continue
 			}


### PR DESCRIPTION
This pull request fixes #28. I'm not sure this is the correct fix but at least better than crash.