### PR TITLE
Include action key in Vim terminal-api callback object

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ gof() {
 [file information] = {
   "filename": [relative filename path (string)],
   "fullpath": [absolute filename path (string)],
-  "root_dir": [root directory (string)]
+  "root_dir": [root directory (string)],
+  "action_key": [action key of -a (string)]
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -775,7 +775,7 @@ loop:
 			for _, f := range selected {
 				command := make([]interface{}, 0, 3)
 				if *terminalApiFuncname != "" {
-					command = append(command, "call", *terminalApiFuncname, newVimTapiCall(cwd, f))
+					command = append(command, "call", *terminalApiFuncname, newVimTapiCall(cwd, f, actionKey))
 				} else {
 					if !filepath.IsAbs(f) {
 						f = filepath.Join(cwd, f)
@@ -808,15 +808,16 @@ loop:
 }
 
 type vimTapiCall struct {
-	RootDir  string `json:"root_dir"`
-	Filename string `json:"filename"`
-	Fullpath string `json:"fullpath"`
+	RootDir   string `json:"root_dir"`
+	Filename  string `json:"filename"`
+	Fullpath  string `json:"fullpath"`
+	ActionKey string `json:"action_key"`
 }
 
-func newVimTapiCall(rootDir, filename string) *vimTapiCall {
+func newVimTapiCall(rootDir, filename, actionKey string) *vimTapiCall {
 	fullpath := filename
 	if !filepath.IsAbs(filename) {
 		fullpath = filepath.Join(rootDir, filename)
 	}
-	return &vimTapiCall{RootDir: rootDir, Filename: filename, Fullpath: fullpath}
+	return &vimTapiCall{RootDir: rootDir, Filename: filename, Fullpath: fullpath, ActionKey: actionKey}
 }


### PR DESCRIPTION
I want to use -a flag from Vim terminal-api (for example, ctrl-v for vnew, ctrl-t for tabnew).