### PR TITLE
Fix sorting comparator

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,12 +193,8 @@ func filter() {
 	}
 	if len(inp) > 0 {
 		sort.Slice(tmp, func(i, j int) bool {
-			if (tmp[i].pos2 - tmp[i].pos1) < (tmp[j].pos2 - tmp[j].pos1) {
-				return true
-			} else if tmp[i].pos1 < tmp[j].pos1 {
-				return true
-			}
-			return false
+			li, lj := tmp[i].pos2-tmp[i].pos1, tmp[j].pos2-tmp[j].pos1
+			return li < lj || li == lj && tmp[i].pos1 < tmp[j].pos1
 		})
 	}
 


### PR DESCRIPTION
Current implementation is not stable and does not correctly sort by length.
See https://play.golang.org/p/0-X4j4w-yeH and  https://play.golang.org/p/Rfn7DMOTKxD.