### PR TITLE
Update ci configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@master
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.x
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@master
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.x
-    - name: Add $GOPATH/bin to $PATH
-      run: echo "::add-path::$(go env GOPATH)/bin"
     - name: Cross build
       run: make cross
     - name: Create Release


### PR DESCRIPTION
- [actions/setup-go v2](https://github.com/actions/setup-go#v2) is released and we don't need to add GOPATH/bin to PATH anymore.
- Update CI triggers not to duplicate on pull requests