### PR TITLE
Use go install instead of go get in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@ VERSION := $$(make -s show-version)
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 BUILD_LDFLAGS := "-s -w -X main.revision=$(CURRENT_REVISION)"
 GOBIN ?= $(shell go env GOPATH)/bin
-export GO111MODULE=on
 
 .PHONY: all
-all: clean build
+all: build
 
 .PHONY: build
 build:
@@ -21,14 +20,14 @@ show-version: $(GOBIN)/gobump
 	@gobump show -r .
 
 $(GOBIN)/gobump:
-	@cd && go get github.com/x-motemen/gobump/cmd/gobump
+	@go install github.com/x-motemen/gobump/cmd/gobump@latest
 
 .PHONY: cross
 cross: $(GOBIN)/goxz
 	goxz -n $(BIN) -pv=v$(VERSION) -build-ldflags=$(BUILD_LDFLAGS) .
 
 $(GOBIN)/goxz:
-	cd && go get github.com/Songmu/goxz/cmd/goxz
+	go install github.com/Songmu/goxz/cmd/goxz@latest
 
 .PHONY: test
 test: build
@@ -39,23 +38,9 @@ clean:
 	rm -rf $(BIN) goxz
 	go clean
 
-.PHONY: bump
-bump: $(GOBIN)/gobump
-ifneq ($(shell git status --porcelain),)
-	$(error git workspace is dirty)
-endif
-ifneq ($(shell git rev-parse --abbrev-ref HEAD),master)
-	$(error current branch is not master)
-endif
-	@gobump up -w .
-	git commit -am "bump up version to $(VERSION)"
-	git tag "v$(VERSION)"
-	git push origin master
-	git push origin "refs/tags/v$(VERSION)"
-
 .PHONY: upload
 upload: $(GOBIN)/ghr
 	ghr "v$(VERSION)" goxz
 
 $(GOBIN)/ghr:
-	cd && go get github.com/tcnksm/ghr
+	go install github.com/tcnksm/ghr@latest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Go Fuzzy
 
 ## Installation
 
-    $ go get github.com/mattn/gof
+    $ go install github.com/mattn/gof@latest
 
 ## Feature
 


### PR DESCRIPTION
I fixed Makefile (and README.md) to use `go install` instead of `go get`.
Also removed `make bump` because you may not use this.